### PR TITLE
Update for 1.09.

### DIFF
--- a/strivehitboxes/arcsys.cpp
+++ b/strivehitboxes/arcsys.cpp
@@ -15,7 +15,7 @@ const auto asw_entity_is_active = (asw_entity_is_active_t)(
 
 using asw_entity_is_pushbox_active_t = bool(*)(const asw_entity*);
 const auto asw_entity_is_pushbox_active = (asw_entity_is_pushbox_active_t)(
-	sigscan::get().scan("\xF7\x80\xEC\x5C", "xxxx") - 0x1A);
+	sigscan::get().scan("\xF7\x80\xCC\x5D", "xxxx") - 0x1A);
 
 using asw_entity_get_pos_x_t = int(*)(const asw_entity*);
 const auto asw_entity_get_pos_x = (asw_entity_get_pos_x_t)(

--- a/strivehitboxes/arcsys.h
+++ b/strivehitboxes/arcsys.h
@@ -8,8 +8,8 @@ class AREDGameState_Battle : public AGameState {
 public:
 	static UClass *StaticClass();
 
-	FIELD(0xB60, class asw_engine*, Engine);
-	FIELD(0xB68, class asw_scene*, Scene);
+	FIELD(0xB70, class asw_engine*, Engine);
+	FIELD(0xB78, class asw_scene*, Scene);
 };
 
 class player_block {

--- a/strivehitboxes/strivehitboxes.vcxproj
+++ b/strivehitboxes/strivehitboxes.vcxproj
@@ -54,7 +54,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>CURL_STATICLIB;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- Update broken offset and signature for 1.09.  New values found by user Zeni in the Unreal anime modding Discord server.

- Set C++ standard to latest for debug builds as well.  This was set for release already.

Tested that this compiles and displays hitboxes again in training.  Closes #16 and closes #17.